### PR TITLE
fixes #25 so parse_file can read string

### DIFF
--- a/cloudside/asos.py
+++ b/cloudside/asos.py
@@ -196,7 +196,7 @@ def parse_file(filepath, new_precipcol='precipitation'):
 
     """
 
-    with filepath.open('r') as rawf:
+    with open(filepath, 'r') as rawf:
         df = pandas.DataFrame(list(map(lambda x: MetarParser(x).asos_dict(), rawf)))
 
     if df.shape[0] == 0:


### PR DESCRIPTION
`asos.parse_file` should accept a string, so this patch fixes that. previous behavior accepted only `pathlib.Path` instances.