### PR TITLE
fixes #30 by making plotting api return axes objects rather than figures

### DIFF
--- a/check_cloudside.py
+++ b/check_cloudside.py
@@ -1,10 +1,10 @@
 import sys
 import matplotlib
+matplotlib.use('agg')
 from matplotlib import style
 
 import cloudside
 
-matplotlib.use('agg')
 style.use('classic')
 
 if '--strict' in sys.argv:

--- a/cloudside/tests/test_viz.py
+++ b/cloudside/tests/test_viz.py
@@ -90,7 +90,9 @@ def rose_index():
 
 @pytest.mark.mpl_image_compare(**IMG_OPTS)
 def test_rain_clock(test_data):
-    fig = viz.rain_clock(test_data, raincol='Precip')
+    fig, ax1, ax2 = _make_polar_fig()
+    fig.set_size_inches(7, 3)
+    axes = viz.rain_clock(test_data, raincol='Precip', axes=[ax1, ax2])
     quiet_layout(fig)
     return fig
 
@@ -204,7 +206,7 @@ def test__compute_rose_short_record(short_data, rose_index):
 def test_hyetograph(test_data, frequencies):
     fig, axes = _make_ts_fig()
     for freq, ax in zip(frequencies, axes):
-        fig = viz.hyetograph(test_data, col='Precip', freq=freq, ax=ax)
+        _ = viz.hyetograph(test_data, col='Precip', freq=freq, ax=ax)
     quiet_layout(fig)
     return fig
 
@@ -213,7 +215,7 @@ def test_hyetograph(test_data, frequencies):
 def test_psychromograph(test_data, frequencies):
     fig, axes = _make_ts_fig()
     for freq, ax in zip(frequencies, axes):
-        fig = viz.psychromograph(test_data, col='AtmPress', freq=freq, ax=ax)
+        _ = viz.psychromograph(test_data, col='AtmPress', freq=freq, ax=ax)
     quiet_layout(fig)
     return fig
 
@@ -222,6 +224,6 @@ def test_psychromograph(test_data, frequencies):
 def test_temperature(test_data, frequencies):
     fig, axes = _make_ts_fig()
     for freq, ax in zip(frequencies, axes):
-        fig = viz.temperature(test_data, col='Temp', freq=freq, ax=ax)
+        _ = viz.temperature(test_data, col='Temp', freq=freq, ax=ax)
     quiet_layout(fig)
     return fig

--- a/cloudside/validate.py
+++ b/cloudside/validate.py
@@ -1,18 +1,17 @@
-from matplotlib import figure
-from matplotlib import axes
+from matplotlib import pyplot
 
 import os
 
 
-def axes_object(ax):
+def axes_object(ax, polar=False):
     """ Checks if a value if an Axes. If None, a new one is created.
     Both the figure and axes are returned (in that order).
 
     """
     if ax is None:
-        fig = figure.Figure()
-        ax = fig.add_subplot(1, 1, 1)
-    elif isinstance(ax, axes.Axes):
+        fig, ax = pyplot.subplots(subplot_kw=dict(polar=polar))
+
+    elif isinstance(ax, pyplot.Axes):
         fig = ax.figure
     else:
         msg = "`ax` must be a matplotlib Axes instance or None"


### PR DESCRIPTION
this PR allows the user to do the following if they want:
```
import matplotlib.pyplot as plt
from cloudside import viz
from cloudside.tests.test_viz import test_data

fig, axes = plt.subplots(2,2,figsize=(20,20), subplot_kw=dict(polar=True))
axes12 = viz.rain_clock(test_data(), raincol='Precip', axes=axes.ravel()[:2])
axes34 = viz.rain_clock(test_data(), raincol='Precip', axes=axes.ravel()[2:])
```
it also means that the example in the docs:
```
import cloudside
data = cloudside.asos.get_data('KPDX', '2012-12-01', '2015-05-01', email='youremail@wherever.com')
cloudside.viz.rose(data, 'wind_speed', 'wind_direction')
```
will actually show something when run in `jupyter`.
